### PR TITLE
Add custom overrides for development team and bundle identifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ DerivedData/
 *.perspectivev3
 !default.perspectivev3
 xcuserdata/
+xcshareddata/
 
 ## Other
 *.moved-aside

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
+## Configuration files
+.dev-team
+.bundle-identifier
+
 ## Build generated
 build/
 DerivedData/

--- a/Podfile
+++ b/Podfile
@@ -1,6 +1,9 @@
 # Uncomment the next line to define a global platform for your project
 # platform :ios, '9.0'
 
+DEFAULT_DEVELOPMENT_TEAM = 'GFSP92A3FB'
+DEFAULT_BUNDLE_IDENTIFIER = 'joshua.simplesequencer'
+
 target 'SimpleSequencer' do
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
   use_frameworks!
@@ -9,4 +12,27 @@ target 'SimpleSequencer' do
   pod 'SVGKit', :git => 'https://github.com/SVGKit/SVGKit.git', :branch => '2.x'
   pod 'AudioKit', '~> 4.0'
 
+end
+
+post_install do |installer|
+  root = File.dirname(__FILE__)
+
+  dev_team_file = File.join(root, ".dev-team")
+  dev_team = DEFAULT_DEVELOPMENT_TEAM
+  if File.exist?(dev_team_file)
+    dev_team = File.read(dev_team_file).chomp
+  end
+
+  bundle_id_file = File.join(root, ".bundle-identifier")
+  bundle_id = DEFAULT_BUNDLE_IDENTIFIER
+  if File.exist?(bundle_id_file)
+    bundle_id = File.read(bundle_id_file).chomp
+  end
+
+  Dir.glob(File.join(root, "Pods/Target Support Files/Pods-SimpleSequencer/*.xcconfig")) do |xcconfig_file|
+    File.open(xcconfig_file, 'a+') do |xcconfig|
+      xcconfig.puts "DEVELOPMENT_TEAM = #{dev_team}"
+      xcconfig.puts "PRODUCT_BUNDLE_IDENTIFIER = #{bundle_id}"
+    end
+  end
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -16,7 +16,7 @@ DEPENDENCIES:
   - SVGKit (from `https://github.com/SVGKit/SVGKit.git`, branch `2.x`)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  https://github.com/cocoapods/specs.git:
     - AudioKit
     - CocoaLumberjack
 
@@ -35,6 +35,6 @@ SPEC CHECKSUMS:
   CocoaLumberjack: 2e258a064cacc8eb9a2aca318e24d02a0a7fd56d
   SVGKit: 4055d9e809b5db8633755979cfb3b02dc5a8c20d
 
-PODFILE CHECKSUM: a3433c0ef5eee59b3f85b32963b39540ff11146a
+PODFILE CHECKSUM: 09326d0ee16f6e71299e50d6a51c08c8b5cf3263
 
-COCOAPODS: 1.5.0
+COCOAPODS: 1.5.3

--- a/SimpleSequencer.xcodeproj/project.pbxproj
+++ b/SimpleSequencer.xcodeproj/project.pbxproj
@@ -413,7 +413,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -501,14 +501,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = GFSP92A3FB;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				INFOPLIST_FILE = SimpleSequencer/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = joshua.simplesequencer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -521,13 +519,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = GFSP92A3FB;
 				INFOPLIST_FILE = SimpleSequencer/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = joshua.simplesequencer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
This should allow us to keep separate development teams and bundle identifiers if needed.

Test plan:
* Run `pod install`, observe that custom values are observed with specially-named files.